### PR TITLE
Fix pages naming bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
-    "start": "set PORT=5550 && react-scripts start",
+    "start": "react-scripts start",
     "build": "react-scripts build",
     "lint": "npx prettier -c src/",
     "test": "react-scripts test",


### PR DESCRIPTION
1. Remove all files from Page folder
2. Create new files with new capitalized names
3. Save and push
![fix-b](https://user-images.githubusercontent.com/39487464/186854198-6772804a-5617-4ccd-8a44-b3b99f89bc4b.JPG)
